### PR TITLE
Custom Diff Algo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The default diff algorithm will convert the old value and the new value to a Str
 var options = {
   diffOnly: true, 
   customDiffAlgo: function(key, newValue, oldValue) {
-    if(key !== tags && String(newValue) != String(oldValue)){
+    if(key !== 'tags' && String(newValue) != String(oldValue)){
       return {
         diff: newValue
       };

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ var options = {diffOnly: true}
 Post.plugin(mongooseHistory, options)
 ```
 
+The default diff algorithm will convert the old value and the new value to a String, and will compare those strings. You can use the customDiffAlgo option to override the diff algorithm. You can do that, for example, in order to ignore the order of elements inside arrays. Here is an even simpler example, that will ignore the updates made to a specific document key (called 'tags'):
+
+```javascript
+var options = {
+  diffOnly: true, 
+  customDiffAlgo: function(key, newValue, oldValue) {
+    if(key !== tags && String(newValue) != String(oldValue)){
+      return {
+        diff: newValue
+      };
+    }
+    // no diff should be recorded for the tags key
+    return null;
+  }
+};
+Post.plugin(mongooseHistory, options)
+```
+
+
 The plugin will create a new collection with format: originalCollectionName +  **_history**, in example: __posts_history__. You can also change the name of the collection by setting the configuration customCollectionName:
 
 ```javascript

--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -4,6 +4,8 @@ var mongoose = require('mongoose')
 
 module.exports = function historyPlugin(schema, options) {
   var customCollectionName  = options && options.customCollectionName;
+  var customDiffAlgo = options && options.customDiffAlgo;
+
   var diffOnly  = options && options.diffOnly;
 
   // Clear all history collection from Schema
@@ -37,11 +39,17 @@ module.exports = function historyPlugin(schema, options) {
       var diff = {};
       diff['_id'] = d['_id'];
       for(var k in d){
-        if(String(d[k]) != String(original[k])){
-          diff[k] = d[k];
+        if(customDiffAlgo) {
+          var customDiff = customDiffAlgo(k, d[k], original[k]);
+          if(customDiff) {
+            diff[k] = customDiff.diff;
+          }
+        } else {
+          if(String(d[k]) != String(original[k])){
+            diff[k] = d[k];
+          }
         }
       }
-
       diff.__v = undefined;
       historyDoc['t'] = new Date();
       historyDoc['o'] = 'u';

--- a/test/diffonly_custom_algo.js
+++ b/test/diffonly_custom_algo.js
@@ -1,0 +1,162 @@
+"use strict";
+
+var should      = require('should'),
+    Post        = require('./model/post_custom_diff'),
+    HistoryPost = Post.historyModel();
+
+require('./config/mongoose');
+
+describe('History plugin custom diff algo', function() {
+
+  var post = null;
+
+  function createAndUpdatePostWithHistory(post, newTags, callback) {
+    post.save(function(err) {
+      if(err) return callback(err);
+      Post.findOne(function(err, post) {
+        if(err) return callback(err);
+        post.updatedFor = 'another_user@test.com';
+        post.title = "Title changed";
+        post.tags = newTags;
+        post.save(function(err) {          
+          if(err) return callback(err);
+          HistoryPost.findOne({'d.title': 'Title changed'}, function(err, hpost) {
+            should.exists(hpost);            
+            callback(err, post, hpost);
+          });
+        });
+      });
+    });
+  };
+
+  var post = null;
+  var defaultTags = ['Brazil', 'France'];
+
+  beforeEach(function(done) {
+    post = new Post({
+      updatedFor: 'mail@test.com',
+      title:   'Title test',
+      message: 'message lorem ipsum test',
+      tags: defaultTags
+    });
+
+    done();
+  });
+
+  afterEach(function(done) {
+    Post.remove({}, function(err) {
+      should.not.exists(err);
+      Post.clearHistory(function(err) {
+        should.not.exists(err);
+        done();
+      });
+    });
+  });
+
+
+  it('should keep insert in history', function(done) {
+    post.save(function(err) {
+      should.not.exists(err);
+      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
+        should.not.exists(err);
+        should.exists(hpost);        
+        hpost.o.should.eql('i');
+        post.should.have.property('updatedFor', hpost.d.updatedFor);
+        post.title.should.be.equal(hpost.d.title);
+        post.should.have.property('message', hpost.d.message);
+        done();
+      });
+    });
+  });
+
+  it('should not care about order of tags', function(done) {
+    should.exists(post);    
+    var newTags = ['France', 'Brazil'];
+    createAndUpdatePostWithHistory(post, newTags, function(err, post, hpost) {
+      should.not.exists(err);
+      should.exists(hpost);
+      hpost.o.should.eql('u');
+      should.not.exists(hpost.d.message);
+      should.not.exists(hpost.d._v);
+      should.not.exists(hpost.d.tags);
+      done();
+    });
+  });
+
+  it('should detect null tags', function(done) {
+    should.exists(post);    
+    var newTags = null;
+    createAndUpdatePostWithHistory(post, newTags, function(err, post, hpost) {
+      should.not.exists(err);
+      should.exists(hpost);
+      hpost.o.should.eql('u');
+      should.not.exists(hpost.d.message);
+      should.not.exists(hpost.d._v);
+      should(hpost.d.tags).be.null();
+      //console.log('%j', hpost);
+      done();
+    });
+  });
+
+  it('should detect new tags', function(done) {
+    should.exists(post);    
+    var newTags = ['Brazil', 'France', 'Australia'];
+    createAndUpdatePostWithHistory(post, newTags, function(err, post, hpost) {
+      should.not.exists(err);
+      should.exists(hpost);
+      hpost.o.should.eql('u');
+      should.not.exists(hpost.d.message);
+      should.not.exists(hpost.d._v);
+      should.exists(hpost.d.tags);
+      hpost.d.tags.should.be.instanceof(Array).and.have.lengthOf(3);
+      hpost.d.tags.should.containEql('Brazil');      
+      hpost.d.tags.should.containEql('France');      
+      hpost.d.tags.should.containEql('Australia');            
+      done();
+    });
+  });
+
+  it('should detect removed tags', function(done) {
+    should.exists(post);    
+    var newTags = ['Brazil'];
+    createAndUpdatePostWithHistory(post, newTags, function(err, post, hpost) {
+      should.not.exists(err);
+      should.exists(hpost);
+      hpost.o.should.eql('u');
+      should.not.exists(hpost.d.message);
+      should.not.exists(hpost.d._v);
+      should.exists(hpost.d.tags);
+      hpost.d.tags.should.be.instanceof(Array).and.have.lengthOf(1);
+      hpost.d.tags.should.containEql('Brazil');                 
+      done();
+    });
+  });
+
+  it('should keep just what changed in update', function(done) {
+    should.exists(post);    
+    createAndUpdatePostWithHistory(post, defaultTags, function(err, post, hpost) {
+      should.not.exists(err);
+      should.exists(hpost);
+      hpost.o.should.eql('u');
+      should.not.exists(hpost.d.message);
+      should.not.exists(hpost.d.tags);      
+      should.not.exists(hpost.d._v);
+      done();
+    });
+  });
+
+  it('should keep remove in history', function(done) {
+    should.exists(post);
+    createAndUpdatePostWithHistory(post, defaultTags, function(err, post, hpost) {
+      should.not.exists(err);
+      should.exists(post);
+      post.remove(function(err) {
+        should.not.exists(err);
+        HistoryPost.find({o: 'r'}).select('d').exec(function(err, historyWithRemove) {
+          historyWithRemove.should.not.be.empty;
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/model/post_custom_diff.js
+++ b/test/model/post_custom_diff.js
@@ -1,0 +1,36 @@
+var mongoose = require('mongoose'),
+Schema   = mongoose.Schema,
+history  = require('../../lib/mongoose-history');
+
+var PostSchema = new Schema({
+	updatedFor: String,
+	title: String,
+	tags: [],
+	message: String
+});
+
+
+var sortIfArray = function(a) {
+	if(Array.isArray(a)) {
+		return a.sort();
+	}
+	return a;
+}
+
+var options = {
+	diffOnly: true, 
+	customDiffAlgo: function(key, newValue, oldValue) {
+		var v1 = sortIfArray(oldValue);
+		var v2 = sortIfArray(newValue);
+		if(String(v1) != String(v2)){
+			return {
+				diff: newValue
+			};
+		}
+		// no diff should be recorded for this key
+		return null;
+	}
+};
+
+PostSchema.plugin(history,options);
+module.exports = mongoose.model('Post_custom_diff', PostSchema);


### PR DESCRIPTION
The default diff algorithm will convert the old value and the new value to a String, and will compare those strings. You can use the customDiffAlgo option to override the diff algorithm. You can do that, for example, in order to ignore the order of elements inside arrays.

This PR includes unit tests + documentation update

https://github.com/nassor/mongoose-history/issues/21
