### PR TITLE
Added metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Clear all History collection;
 
 ## TODO
 * **TTL documents**
-* **Store additional metadata**
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ var options = {historyConnection: secondConn}
 Post.plugin(mongooseHistory, options)
 ```
 
+### Store metadata
+If you need to store aditionnal data, use the ```metadata``` option
+It accepts a collection of objects. The parameters ```key``` and ```value``` are required. 
+You can specify mongoose options using the parameter ```schema``` (defaults to ```{type: mongoose.Schema.Types.Mixed}```)
+```value``` can be either a String (resolved from the updated object), or a function, sync or async
+
+```javascript
+var options = {
+  metadata: [
+    {key: 'title', value: 'title'},
+    {key: 'titleFunc', value: function(original, newObject){return newObject.title}},
+    {key: 'titleAsync', value: function(original, newObject, cb){cb(null, newObject.title)}}
+  ]
+};
+PostSchema.plugin(history,options);
+module.exports = mongoose.model('Post_meta', PostSchema);
+```
 
 ### Statics
 All modules with history plugin have following methods:

--- a/lib/history-model.js
+++ b/lib/history-model.js
@@ -11,13 +11,20 @@ const historyModels = {};
 module.exports.HistoryModel = function(collectionName, options) {
   const indexes = options && options.indexes;
   const historyConnection = options && options.historyConnection;
+  const metadata = options && options.metadata;
 
+  let schemaObject = {
+    t: {type: Date, required: true},
+    o: {type: String, required: true},
+    d: {type: mongoose.Schema.Types.Mixed, required: true}
+  }
+  if (metadata){
+    metadata.forEach((m) =>{
+      schemaObject[m.key] = m.schema || {type: mongoose.Schema.Types.Mixed}
+    })
+  }
   if (!(collectionName in historyModels)) {
-    let schema = new mongoose.Schema({
-      t: {type: Date, required: true},
-      o: {type: String, required: true},
-      d: {type: mongoose.Schema.Types.Mixed, required: true}
-    },{ id: true, versionKey: false });
+    let schema = new mongoose.Schema(schemaObject, { id: true, versionKey: false });
 
     if(indexes){
       indexes.forEach(function(idx) {

--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -29,6 +29,28 @@ module.exports = function historyPlugin(schema, options) {
     }
   });
 
+  function setMetadata(original, d, historyDoc, callback){
+    async.each(metadata, (m, cb) => {
+      if (typeof(m.value) === 'function'){
+        if (m.value.length === 3){
+          /** async function */
+          m.value(original, d, function(err, data){
+            if (err) cb(err);
+            historyDoc[m.key] = data;
+            cb();
+          })
+        } else {
+          historyDoc[m.key] = m.value(original, d);
+          cb();
+        }
+      } else {
+        historyDoc[ m.key] = d ? d[ m.value] : null;
+        cb();
+      }
+    }, callback)
+  }
+
+
   // Create an copy when insert or update, or a diff log
   schema.pre('save', function(next) {
     const historyDoc = {};
@@ -64,24 +86,7 @@ module.exports = function historyPlugin(schema, options) {
     }
 
     if (metadata){
-      async.each(metadata, (m, cb) => {
-        if (typeof(m.value) === 'function'){
-          if (m.value.length === 3){
-            /** async function */
-            m.value(original, d, function(err, data){
-              if (err) cb(err);
-              historyDoc[m.key] = data;
-              cb();
-            })
-          } else {
-            historyDoc[m.key] = m.value(original, d);
-            cb();
-          }
-        } else {
-          historyDoc[ m.key] = d[ m.value];
-          cb();
-        }
-      },(err) => {
+      setMetadata(original, d, historyDoc, (err) => {
         if (err) return next(err)
         let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
         history.save(next);
@@ -90,7 +95,6 @@ module.exports = function historyPlugin(schema, options) {
       let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
       history.save(next);
     }
-
   });
 
   // Listen on update
@@ -102,22 +106,33 @@ module.exports = function historyPlugin(schema, options) {
     historyDoc['t'] = new Date();
     historyDoc['o'] = 'u';
     historyDoc['d'] = d;
-
-    let history = new hm.HistoryModel(hm.historyCollectionName(this.mongooseCollection.collectionName, customCollectionName), options)(historyDoc);
-    history.save(next);
+    if (metadata){
+      setMetadata(this.toObject, d, historyDoc, (err) => {
+        let history = new hm.HistoryModel(hm.historyCollectionName(this.mongooseCollection.collectionName, customCollectionName), options)(historyDoc);
+        history.save(next);
+      })
+    } else {
+      let history = new hm.HistoryModel(hm.historyCollectionName(this.mongooseCollection.collectionName, customCollectionName), options)(historyDoc);
+      history.save(next);
+    }
   });
 
   // Create an copy when insert or update
   schema.pre('remove', function(next) {
     let d = this.toObject();
     d.__v = undefined;
-
     let historyDoc = {};
     historyDoc['t'] = new Date();
     historyDoc['o'] = 'r';
     historyDoc['d'] = d;
-
-    let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
-    history.save(next);
+    if (metadata){
+      setMetadata(this.toObject(), this.toObject(), historyDoc, (err) =>{
+        let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
+        history.save(next);
+      })
+    } else {
+      let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
+      history.save(next);
+    }
   });
 };

--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -1,11 +1,13 @@
 "use strict";
 const mongoose = require('mongoose');
 const hm = require('./history-model');
+const async = require('async')
 
 module.exports = function historyPlugin(schema, options) {
   const customCollectionName  = options && options.customCollectionName;
   const customDiffAlgo = options && options.customDiffAlgo;
   const diffOnly  = options && options.diffOnly;
+  const metadata = options && options.metadata;
 
   // Clear all history collection from Schema
   schema.statics.historyModel = function() {
@@ -61,8 +63,34 @@ module.exports = function historyPlugin(schema, options) {
       historyDoc['d'] = d;
     }
 
-    let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
-    history.save(next);
+    if (metadata){
+      async.each(metadata, (m, cb) => {
+        if (typeof(m.value) === 'function'){
+          if (m.value.length === 3){
+            /** async function */
+            m.value(original, d, function(err, data){
+              if (err) cb(err);
+              historyDoc[m.key] = data;
+              cb();
+            })
+          } else {
+            historyDoc[m.key] = m.value(original, d);
+            cb();
+          }
+        } else {
+          historyDoc[ m.key] = d[ m.value];
+          cb();
+        }
+      },(err) => {
+        if (err) return next(err)
+        let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
+        history.save(next);
+      })
+    } else {
+      let history = new hm.HistoryModel(hm.historyCollectionName(this.collection.name, customCollectionName), options)(historyDoc);
+      history.save(next);
+    }
+
   });
 
   // Listen on update

--- a/package.json
+++ b/package.json
@@ -21,28 +21,28 @@
     "backup"
   ],
   "author": {
-      "name": "Nassor Paulino da Silva",
-      "email": "nassor@gmail.com",
-      "url": "https://github.com/nassor"
+    "name": "Nassor Paulino da Silva",
+    "email": "nassor@gmail.com",
+    "url": "https://github.com/nassor"
   },
   "contributors": [
     {
-      "name" : "Christopher Britz",
-      "email" : "britztopher@gmail.com",
-      "url" : "https://github.com/britztopher"
+      "name": "Christopher Britz",
+      "email": "britztopher@gmail.com",
+      "url": "https://github.com/britztopher"
     },
     {
-      "name" : "Allan Nienhuis",
-      "url" : "https://github.com/allannienhuis"
+      "name": "Allan Nienhuis",
+      "url": "https://github.com/allannienhuis"
     },
     {
-      "name" : "João Manoel Pampanini Filho",
-      "email" : "joao.bontorin@gmail.com",
-      "url" : "https://github.com/jmpf13"
+      "name": "João Manoel Pampanini Filho",
+      "email": "joao.bontorin@gmail.com",
+      "url": "https://github.com/jmpf13"
     },
     {
-      "name" : "Sebastien Vaucouleur",
-      "url" : "http://vaucouleur.com"
+      "name": "Sebastien Vaucouleur",
+      "url": "http://vaucouleur.com"
     }
   ],
   "license": "BSD-2-Clause",
@@ -50,8 +50,8 @@
     "url": "https://github.com/nassor/mongoose-history/issues"
   },
   "dependencies": {
+    "async": "^2.0.0-rc.3",
     "mongoose": "^4.0.0"
-
   },
   "devDependencies": {
     "mocha": "2.4.5",

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,0 +1,85 @@
+"use strict";
+
+var should      = require('should')
+  , Post        = require('./model/post_metadata')
+  , HistoryPost = Post.historyModel();
+
+require('./config/mongoose');
+
+describe('History plugin with Metadata', function() {
+
+  var post = null;
+
+  function createAndUpdatePostWithHistory(post, callback) {
+    post.save(function(err) {
+      if(err) return callback(err);
+      Post.findOne(function(err, post) {
+        if(err) return callback(err);
+        post.updatedFor = 'another_user@test.com';
+        post.title = "Title changed";
+        post.save(function(err) {
+          if(err) return callback(err);
+          HistoryPost.findOne({'d.title': 'Title changed'}, function(err, hpost) {
+            callback(err, post, hpost);
+          });
+        });
+      });
+    });
+  };
+
+  var post = null;
+
+  beforeEach(function(done) {
+    post = new Post({
+      updatedFor: 'mail@test.com',
+      title:   'Title test',
+      message: 'message lorem ipsum test'
+    });
+
+    done();
+  });
+
+  afterEach(function(done) {
+    Post.remove({}, function(err) {
+      should.not.exists(err);
+      Post.clearHistory(function(err) {
+        should.not.exists(err);
+        done();
+      });
+    });
+  });
+
+  it('should set simple field', function(done) {
+    post.save(function(err) {
+      should.not.exists(err);
+      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
+        should.not.exists(err);
+        hpost.title.should.eql('Title test');
+        done();
+      });
+    });
+  });
+
+  it('should set function field', function(done) {
+    post.save(function(err) {
+      should.not.exists(err);
+      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
+        should.not.exists(err);
+        hpost.titleFunc.should.eql('Title test');
+        done();
+      });
+    });
+  });
+
+  it('should set async field', function(done) {
+    post.save(function(err) {
+      should.not.exists(err);
+      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
+        should.not.exists(err);
+        hpost.titleAsync.should.eql('Title test');
+        done();
+      });
+    });
+  });
+
+});

--- a/test/model.js
+++ b/test/model.js
@@ -4,6 +4,7 @@ var should          = require('should')
   , hm              = require('../lib/history-model')
   , Post            = require('./model/post-with-index')
   , PostAnotherConn = require('./model/post-another-conn')
+  , PostMetadata    = require('./model/post_metadata')
   , secondConn      = require('mongoose').createConnection('mongodb://localhost/mongoose-history-test-second');
 
 require('./config/mongoose');
@@ -72,6 +73,11 @@ describe('History Model', function() {
       });
     });
   });
+
+  it ('could have additionnal metadata fields', function(){
+    var HistoryPost = PostMetadata.historyModel();
+    HistoryPost.schema.paths.should.have.property('title')
+  })
 
   
 });

--- a/test/model/post_diff.js
+++ b/test/model/post_diff.js
@@ -11,4 +11,4 @@ var PostSchema = new Schema({
 var options = {diffOnly: true};
 PostSchema.plugin(history,options);
 
-module.exports = mongoose.model('Post_diff', PostSchema);
+module.exports = mongoose.model('Post_metadata', PostSchema);

--- a/test/model/post_metadata.js
+++ b/test/model/post_metadata.js
@@ -1,0 +1,20 @@
+var mongoose = require('mongoose')
+  , Schema   = mongoose.Schema
+  , history  = require('../../lib/mongoose-history');
+
+var PostSchema = new Schema({
+    updatedFor: String
+  , title: String
+  , message: String
+});
+
+var options = {
+  metadata: [
+    {key: 'title', value: 'title'},
+    {key: 'titleFunc', value: function(origin, d){return d.title}},
+    {key: 'titleAsync', value: function(original, d, cb){cb(null, d.title)}}
+  ]
+};
+PostSchema.plugin(history,options);
+
+module.exports = mongoose.model('Post_meta', PostSchema);


### PR DESCRIPTION
You can now pass a ```metadata``` collection to your options, so that extra fields will be added on the history model. You can even pass extra mongoose-schema options (such as ref, to play nicely with ```populate```)