### PR TITLE
change mongoose as peerDependency in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ addons:
     packages:
     - mongodb-org-server
 node_js:
-  - "5.4.0"
-  - "4.3.0"
+  - "4"
+  - "6"
+  - "8"
 before_script:
   - npm install
 notifications:

--- a/package.json
+++ b/package.json
@@ -54,11 +54,15 @@
     "url": "https://github.com/nassor/mongoose-history/issues"
   },
   "dependencies": {
-    "async": "^2.0.0-rc.3",
-    "mongoose": "^4.0.0"
   },
   "devDependencies": {
+    "async": "^2.6.0",
+    "mongoose": "^4.0.0",
     "mocha": "2.4.5",
     "should": "8.2.2"
+  },
+  "peerDependencies": {
+    "async": "^2.0.0",
+    "mongoose": "^4.0.0 || >=5.0.0"
   }
 }


### PR DESCRIPTION
Fix #39
This change on the `package.json` allows to use this plugin with `mongoose@5`, otherwise this plugin installs an instance of `mongoose@4`.