### PR TITLE
fix: enable using mongoose 5

### DIFF
--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -86,7 +86,7 @@ module.exports = function historyPlugin(schema, options) {
 
   // Listen on update
   schema.pre('update', function(next) {
-    let d = this._update.$set;
+    let d = this._update.$set || this._update;
     let historyDoc = createHistoryDoc(d, 'u');
 
     saveHistoryModel(this.toObject, d, historyDoc, this.mongooseCollection.collectionName, next);

--- a/package.json
+++ b/package.json
@@ -53,11 +53,10 @@
   "bugs": {
     "url": "https://github.com/nassor/mongoose-history/issues"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "async": "^2.6.0",
-    "mongoose": "^4.0.0",
+    "mongoose": "^5.0.0",
     "mocha": "2.4.5",
     "should": "8.2.2"
   },


### PR DESCRIPTION
Re: Automattic/mongoose#6167

I bumped the dev mongoose version to 5.x and fixed a compatibility issue. Tests still succeed with mongoose 4 as far as I can tell.

As @lineus [astutely pointed out](https://github.com/Automattic/mongoose/issues/6167#issuecomment-368527827), in mongoose 5 we made it so that [query casting doesn't happen until you actually `exec()` the query](https://github.com/Automattic/mongoose/blob/master/migrating_to_5.md#query-casting), so update middleware will see what the user passed in rather than a half-casted query like in mongoose 4. In other words, if the user does this:

```javascript
// `this._update` will be `{ foo: 'bar' }` in mongoose 5, instead of `{ $set: { foo: 'bar' } }` in mongoose 4
doc.update({}, { foo: 'bar' });
```

However, the user can also do this:

```javascript
// `this._update` will be `{ $set: { foo: 'bar' } }` in both mongoose 4 and mongoose 5
doc.update({}, { $set: { foo: 'bar' } });
```

So you need to be able to handle both cases. Hope this helps!