### PR TITLE
fix: Remove deletion of __v when creating history doc

### DIFF
--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -113,12 +113,12 @@ module.exports = function historyPlugin(schema, options) {
   });
 
   function createHistoryDoc(d, operation) {
-    d.__v = undefined;
+    const { __v, ...doc } = d;
 
     let historyDoc = {};
     historyDoc['t'] = new Date();
     historyDoc['o'] = operation;
-    historyDoc['d'] = d;
+    historyDoc['d'] = doc;
 
     return historyDoc;
   }


### PR DESCRIPTION
Setting __v to undefined causes the main document to be saved with a version key of `null` in some cases.

This fix addresses the following issues:
https://github.com/nassor/mongoose-history/issues/58
https://github.com/nassor/mongoose-history/issues/45