### PR TITLE
feat: Require Node.js >= 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ services:
 addons:
   apt:
     sources:
-    - mongodb-3.0-precise
+      - mongodb-3.0-precise
     packages:
-    - mongodb-org-server
+      - mongodb-org-server
 node_js:
-  - "4"
-  - "6"
-  - "8"
+  - '8'
+  - '10'
+  - '12'
+  - '14'
 before_script:
   - npm install
 notifications:


### PR DESCRIPTION
BREAKING CHANGE: This drops support for Node.js 4 and 6